### PR TITLE
Implement network layer with NetworkX-backed topology

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -203,3 +203,11 @@ cython_debug/
 marimo/_static/
 marimo/_lsp/
 __marimo__/
+
+# Claude Code local config (permissions, session state, etc.)
+.claude/
+
+# Local SQLite databases created at runtime by node.py
+*.db
+*.sqlite
+*.sqlite3

--- a/.gitignore
+++ b/.gitignore
@@ -206,8 +206,3 @@ __marimo__/
 
 # Claude Code local config (permissions, session state, etc.)
 .claude/
-
-# Local SQLite databases created at runtime by node.py
-*.db
-*.sqlite
-*.sqlite3

--- a/network.py
+++ b/network.py
@@ -1,0 +1,171 @@
+"""
+network.py — NetworkX-backed topology for the ColonySearch swarm.
+
+Owns the node registry, directed graph, and per-edge pheromone values.
+Used by router.py (neighbor lookup, pheromone read), reputation.py
+(pheromone and reputation writes), and visualise.py (graph layout).
+
+Design notes:
+- DiGraph so pheromone can be asymmetric (A→B trail ≠ B→A trail),
+  matching standard ACO literature.
+- Pheromone is floored at MIN_PHEROMONE so no edge fully dies.
+- Topology factories guarantee connectivity — isolated nodes break routing.
+"""
+
+from __future__ import annotations
+
+import random
+
+import networkx as nx
+
+INITIAL_PHEROMONE: float = 1.0  # τ_0 per ACO convention
+MIN_PHEROMONE: float = 0.01     # floor to keep all edges alive
+
+
+class Network:
+    def __init__(self) -> None:
+        self._graph: nx.DiGraph = nx.DiGraph()
+
+    # ------------------------------------------------------------------
+    # Node registration
+    # ------------------------------------------------------------------
+
+    def register_node(self, node_id: str, node_obj=None, reputation: float = 1.0) -> None:
+        """Add node_id to the topology. node_obj is the Node instance (may be None during setup)."""
+        self._graph.add_node(node_id, node=node_obj, reputation=reputation)
+
+    def attach_node_obj(self, node_id: str, node_obj) -> None:
+        """Bind a Node instance to an already-registered node_id."""
+        self._graph.nodes[node_id]["node"] = node_obj
+
+    def get_node_obj(self, node_id: str):
+        """Return the Node instance for node_id, or None if not yet attached."""
+        return self._graph.nodes[node_id].get("node")
+
+    def node_ids(self) -> list[str]:
+        return list(self._graph.nodes)
+
+    def __contains__(self, node_id: str) -> bool:
+        return node_id in self._graph
+
+    # ------------------------------------------------------------------
+    # Edge management
+    # ------------------------------------------------------------------
+
+    def add_edge(self, src: str, dst: str, pheromone: float = INITIAL_PHEROMONE) -> None:
+        """Add directed edge src→dst with the given initial pheromone level."""
+        self._graph.add_edge(src, dst, pheromone=max(pheromone, MIN_PHEROMONE))
+
+    def add_undirected_edge(self, a: str, b: str, pheromone: float = INITIAL_PHEROMONE) -> None:
+        """Add symmetric edges a→b and b→a (standard mesh connection)."""
+        self.add_edge(a, b, pheromone)
+        self.add_edge(b, a, pheromone)
+
+    def has_edge(self, src: str, dst: str) -> bool:
+        return self._graph.has_edge(src, dst)
+
+    # ------------------------------------------------------------------
+    # Pheromone access — router.py and reputation.py use these
+    # ------------------------------------------------------------------
+
+    def pheromone(self, src: str, dst: str) -> float:
+        return self._graph[src][dst]["pheromone"]
+
+    def set_pheromone(self, src: str, dst: str, value: float) -> None:
+        self._graph[src][dst]["pheromone"] = max(value, MIN_PHEROMONE)
+
+    def all_edges_pheromone(self) -> dict[tuple[str, str], float]:
+        """Snapshot of all edge pheromone values — used by visualise.py."""
+        return {(u, v): d["pheromone"] for u, v, d in self._graph.edges(data=True)}
+
+    # ------------------------------------------------------------------
+    # Reputation access — reputation.py reads and writes these
+    # ------------------------------------------------------------------
+
+    def reputation(self, node_id: str) -> float:
+        return self._graph.nodes[node_id]["reputation"]
+
+    def set_reputation(self, node_id: str, value: float) -> None:
+        self._graph.nodes[node_id]["reputation"] = max(value, 0.0)
+
+    # ------------------------------------------------------------------
+    # Routing helpers — router.py uses these
+    # ------------------------------------------------------------------
+
+    def neighbors(self, node_id: str) -> list[str]:
+        """Nodes reachable from node_id via a directed edge."""
+        return list(self._graph.successors(node_id))
+
+    # ------------------------------------------------------------------
+    # Raw graph — visualise.py and NetworkX utilities need direct access
+    # ------------------------------------------------------------------
+
+    @property
+    def graph(self) -> nx.DiGraph:
+        return self._graph
+
+    # ------------------------------------------------------------------
+    # Topology factories
+    # ------------------------------------------------------------------
+
+    @classmethod
+    def build_random_mesh(
+        cls,
+        node_ids: list[str],
+        edge_probability: float = 0.4,
+        seed: int = 42,
+    ) -> "Network":
+        """
+        Erdős–Rényi random graph with guaranteed connectivity.
+
+        Each pair (i, j) gets a symmetric edge with probability edge_probability.
+        A random spanning tree is layered on top to ensure no node is isolated —
+        critical for routing correctness.
+        """
+        net = cls()
+        for nid in node_ids:
+            net.register_node(nid)
+
+        rng = random.Random(seed)
+        n = len(node_ids)
+        edges: set[tuple[str, str]] = set()
+
+        for i in range(n):
+            for j in range(i + 1, n):
+                if rng.random() < edge_probability:
+                    edges.add((node_ids[i], node_ids[j]))
+
+        # Spanning tree pass — ensures every node is reachable
+        shuffled = node_ids[:]
+        rng.shuffle(shuffled)
+        for i in range(1, len(shuffled)):
+            a, b = shuffled[i - 1], shuffled[i]
+            # Canonical order avoids adding the same pair twice
+            edges.add((min(a, b), max(a, b)))
+
+        for a, b in edges:
+            net.add_undirected_edge(a, b)
+
+        return net
+
+    @classmethod
+    def build_ring(cls, node_ids: list[str]) -> "Network":
+        """Ring topology: each node connects only to its two neighbours."""
+        net = cls()
+        for nid in node_ids:
+            net.register_node(nid)
+        n = len(node_ids)
+        for i in range(n):
+            net.add_undirected_edge(node_ids[i], node_ids[(i + 1) % n])
+        return net
+
+    @classmethod
+    def build_fully_connected(cls, node_ids: list[str]) -> "Network":
+        """Clique: every node has a direct edge to every other node."""
+        net = cls()
+        for nid in node_ids:
+            net.register_node(nid)
+        for i, a in enumerate(node_ids):
+            for b in node_ids[i + 1:]:
+                net.add_undirected_edge(a, b)
+        return net

--- a/tests/test_network.py
+++ b/tests/test_network.py
@@ -1,0 +1,248 @@
+"""Tests for network.py — node registration, edges, pheromone, and topology factories."""
+
+import pytest
+import networkx as nx
+
+from network import Network, INITIAL_PHEROMONE, MIN_PHEROMONE
+
+
+NODES = ["n0", "n1", "n2", "n3", "n4"]
+
+
+# ---------------------------------------------------------------------------
+# Node registration
+# ---------------------------------------------------------------------------
+
+def test_register_node_present():
+    net = Network()
+    net.register_node("n0")
+    assert "n0" in net
+
+def test_register_node_default_reputation():
+    net = Network()
+    net.register_node("n0")
+    assert net.reputation("n0") == 1.0
+
+def test_register_node_custom_reputation():
+    net = Network()
+    net.register_node("n0", reputation=0.5)
+    assert net.reputation("n0") == 0.5
+
+def test_register_node_obj_attach():
+    net = Network()
+    net.register_node("n0")
+    assert net.get_node_obj("n0") is None
+    sentinel = object()
+    net.attach_node_obj("n0", sentinel)
+    assert net.get_node_obj("n0") is sentinel
+
+def test_node_ids_returns_all():
+    net = Network()
+    for nid in NODES:
+        net.register_node(nid)
+    assert set(net.node_ids()) == set(NODES)
+
+
+# ---------------------------------------------------------------------------
+# Edge creation and pheromone
+# ---------------------------------------------------------------------------
+
+def test_add_directed_edge_exists():
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.add_edge("a", "b")
+    assert net.has_edge("a", "b")
+    assert not net.has_edge("b", "a")
+
+def test_add_undirected_edge_both_directions():
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.add_undirected_edge("a", "b")
+    assert net.has_edge("a", "b")
+    assert net.has_edge("b", "a")
+
+def test_initial_pheromone_default():
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.add_edge("a", "b")
+    assert net.pheromone("a", "b") == INITIAL_PHEROMONE
+
+def test_initial_pheromone_custom():
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.add_edge("a", "b", pheromone=3.7)
+    assert net.pheromone("a", "b") == pytest.approx(3.7)
+
+def test_set_pheromone():
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.add_edge("a", "b")
+    net.set_pheromone("a", "b", 5.0)
+    assert net.pheromone("a", "b") == pytest.approx(5.0)
+
+def test_pheromone_floored_at_minimum():
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.add_edge("a", "b")
+    net.set_pheromone("a", "b", 0.0)
+    assert net.pheromone("a", "b") == pytest.approx(MIN_PHEROMONE)
+
+def test_asymmetric_pheromone():
+    """DiGraph allows different pheromone in each direction."""
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.add_undirected_edge("a", "b")
+    net.set_pheromone("a", "b", 2.0)
+    net.set_pheromone("b", "a", 4.0)
+    assert net.pheromone("a", "b") == pytest.approx(2.0)
+    assert net.pheromone("b", "a") == pytest.approx(4.0)
+
+def test_all_edges_pheromone_snapshot():
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.register_node("c")
+    net.add_undirected_edge("a", "b")
+    net.add_edge("b", "c", pheromone=2.5)
+    snapshot = net.all_edges_pheromone()
+    assert snapshot[("a", "b")] == pytest.approx(INITIAL_PHEROMONE)
+    assert snapshot[("b", "a")] == pytest.approx(INITIAL_PHEROMONE)
+    assert snapshot[("b", "c")] == pytest.approx(2.5)
+
+
+# ---------------------------------------------------------------------------
+# Reputation
+# ---------------------------------------------------------------------------
+
+def test_set_reputation():
+    net = Network()
+    net.register_node("n0")
+    net.set_reputation("n0", 0.8)
+    assert net.reputation("n0") == pytest.approx(0.8)
+
+def test_reputation_floored_at_zero():
+    net = Network()
+    net.register_node("n0")
+    net.set_reputation("n0", -1.0)
+    assert net.reputation("n0") == pytest.approx(0.0)
+
+
+# ---------------------------------------------------------------------------
+# Routing helpers
+# ---------------------------------------------------------------------------
+
+def test_neighbors_directed():
+    net = Network()
+    for nid in ["a", "b", "c"]:
+        net.register_node(nid)
+    net.add_edge("a", "b")
+    net.add_edge("a", "c")
+    assert set(net.neighbors("a")) == {"b", "c"}
+    assert net.neighbors("b") == []
+
+def test_neighbors_after_undirected_edge():
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.add_undirected_edge("a", "b")
+    assert "b" in net.neighbors("a")
+    assert "a" in net.neighbors("b")
+
+
+# ---------------------------------------------------------------------------
+# Raw graph property
+# ---------------------------------------------------------------------------
+
+def test_graph_is_digraph():
+    net = Network()
+    assert isinstance(net.graph, nx.DiGraph)
+
+def test_graph_shares_state():
+    """net.graph must be the live graph, not a copy."""
+    net = Network()
+    net.register_node("a")
+    net.register_node("b")
+    net.add_edge("a", "b")
+    assert net.graph.has_edge("a", "b")
+
+
+# ---------------------------------------------------------------------------
+# Topology factories
+# ---------------------------------------------------------------------------
+
+class TestRandomMesh:
+    def _net(self, n=6, p=0.4, seed=0):
+        ids = [f"n{i}" for i in range(n)]
+        return Network.build_random_mesh(ids, edge_probability=p, seed=seed)
+
+    def test_all_nodes_registered(self):
+        net = self._net()
+        assert len(net.node_ids()) == 6
+
+    def test_connected(self):
+        net = self._net()
+        assert nx.is_weakly_connected(net.graph)
+
+    def test_initial_pheromone_on_all_edges(self):
+        net = self._net()
+        for _, _, d in net.graph.edges(data=True):
+            assert d["pheromone"] == pytest.approx(INITIAL_PHEROMONE)
+
+    def test_deterministic(self):
+        ids = [f"n{i}" for i in range(8)]
+        net1 = Network.build_random_mesh(ids, seed=7)
+        net2 = Network.build_random_mesh(ids, seed=7)
+        assert set(net1.graph.edges()) == set(net2.graph.edges())
+
+    def test_different_seeds_differ(self):
+        ids = [f"n{i}" for i in range(10)]
+        net1 = Network.build_random_mesh(ids, seed=1)
+        net2 = Network.build_random_mesh(ids, seed=99)
+        # Very unlikely to produce identical edge sets with n=10
+        assert set(net1.graph.edges()) != set(net2.graph.edges())
+
+
+class TestRing:
+    def test_each_node_has_two_neighbors(self):
+        ids = [f"n{i}" for i in range(5)]
+        net = Network.build_ring(ids)
+        for nid in ids:
+            assert len(net.neighbors(nid)) == 2
+
+    def test_connected(self):
+        ids = [f"n{i}" for i in range(5)]
+        net = Network.build_ring(ids)
+        assert nx.is_weakly_connected(net.graph)
+
+    def test_initial_pheromone(self):
+        ids = ["a", "b", "c"]
+        net = Network.build_ring(ids)
+        for _, _, d in net.graph.edges(data=True):
+            assert d["pheromone"] == pytest.approx(INITIAL_PHEROMONE)
+
+
+class TestFullyConnected:
+    def test_edge_count(self):
+        ids = [f"n{i}" for i in range(4)]
+        net = Network.build_fully_connected(ids)
+        # 4 nodes → 4*3 directed edges (each pair gets both directions)
+        assert net.graph.number_of_edges() == 4 * 3
+
+    def test_every_node_reaches_every_other(self):
+        ids = [f"n{i}" for i in range(4)]
+        net = Network.build_fully_connected(ids)
+        for a in ids:
+            assert set(net.neighbors(a)) == set(ids) - {a}
+
+    def test_initial_pheromone(self):
+        ids = ["x", "y", "z"]
+        net = Network.build_fully_connected(ids)
+        for _, _, d in net.graph.edges(data=True):
+            assert d["pheromone"] == pytest.approx(INITIAL_PHEROMONE)


### PR DESCRIPTION
Closes #3 

- Network class wrapping nx.DiGraph (directed so pheromone can be asymmetric)
- Node registration with reputation + optional Node-object attachment
- Edge creation (directed and symmetric) with initial pheromone tau_0 = 1.0
- Pheromone min floor of 0.01 to prevent dead edges
- Topology factories: random mesh (with spanning-tree connectivity guarantee), ring, fully connected
- 30 unit tests covering all public API and topology invariants