### PR TITLE
Improve scraper Wikipedia scalability

### DIFF
--- a/data/scraper.py
+++ b/data/scraper.py
@@ -25,7 +25,7 @@ import time
 import xml.etree.ElementTree as ET
 from collections import deque
 from pathlib import Path
-from urllib.parse import urljoin, urlparse
+from urllib.parse import unquote, urljoin, urlparse
 
 import requests
 from bs4 import BeautifulSoup
@@ -1357,7 +1357,7 @@ def crawl(
             for doc in docs:
                 # Wikidata returns placeholder docs → re-queue as wikipedia
                 if doc["source"] == "wikidata_ref":
-                    wt  = _title_from_wiki_url(doc["url"])
+                    wt  = unquote(_title_from_wiki_url(doc["url"]))
                     wk  = f"wikipedia::{wt}"
                     if wk not in visited:
                         q.append(("wikipedia", wt, dlevel))
@@ -1397,7 +1397,7 @@ def crawl(
                         wiki_links = doc["links"][:]
                         random.shuffle(wiki_links)
                         for link in wiki_links[:WIKI_FOLLOW_LIMIT]:
-                            art = _title_from_wiki_url(link)
+                            art = unquote(_title_from_wiki_url(link))
                             lk  = f"wikipedia::{art}"
                             if lk not in visited:
                                 q.append(("wikipedia", art, dlevel + 1))
@@ -1545,7 +1545,7 @@ examples:
             overwrite  = args.overwrite,
             max_body   = args.max_body,
             max_links  = args.max_links,
-            topics     = {t.strip() for t in args.topics.split(",")} if args.topics else None,
+            topics     = {t.strip() for t in args.topics.split(",")} if args.topics else None
         )
         return
 
@@ -1586,6 +1586,8 @@ examples:
 
     if args.wiki_cats:
         cats = [c.strip() for c in args.wiki_cats.split(",") if c.strip()]
+        # Copy seeds lists before appending so TOPIC_CLUSTERS is never mutated.
+        clusters = {t: {**conf, "seeds": list(conf["seeds"])} for t, conf in clusters.items()}
         for topic in clusters:
             for cat in cats:
                 clusters[topic]["seeds"].append(("wikipedia_category", cat))

--- a/data/scraper.py
+++ b/data/scraper.py
@@ -1057,80 +1057,122 @@ def _rebuild_abstract(inv: dict | None) -> str:
     ))
 
 def fetch_openalex(query: str, topic: str,
-                   max_body: int | None = None, max_links: int | None = None) -> list[dict]:
-    r = _get("https://api.openalex.org/works", params={
-        "search": query, "per-page": 5,
-        "select": "id,title,abstract_inverted_index,concepts,doi",
-        "mailto": "research@example.com",
-    })
-    if not r:
-        return []
-    docs = []
-    for work in r.json().get("results", []):
-        title   = work.get("title") or ""
-        body    = _rebuild_abstract(work.get("abstract_inverted_index"))
-        body   += " " + " ".join(c["display_name"] for c in work.get("concepts", []))
-        body    = body.strip()
-        body    = body[:max_body] if max_body else body
-        url     = work.get("doi") or work.get("id", "")
-        if title and body and url:
-            docs.append(_doc(url=url, title=title, body=body,
-                             links=[], source="openalex", source_base=_base_url(url),
-                             topic=topic))
+                   max_body: int | None = None, max_links: int | None = None,
+                   max_results: int = 5) -> list[dict]:
+    per_page = min(max_results, 200)  # API hard cap is 200
+    docs: list[dict] = []
+    page = 1
+    while len(docs) < max_results:
+        r = _get("https://api.openalex.org/works", params={
+            "search": query, "per-page": per_page, "page": page,
+            "select": "id,title,abstract_inverted_index,concepts,doi",
+            "mailto": "research@example.com",
+        })
+        if not r:
+            break
+        results = r.json().get("results", [])
+        if not results:
+            break
+        for work in results:
+            title = work.get("title") or ""
+            body  = _rebuild_abstract(work.get("abstract_inverted_index"))
+            body += " " + " ".join(c["display_name"] for c in work.get("concepts", []))
+            body  = body.strip()
+            body  = body[:max_body] if max_body else body
+            url   = work.get("doi") or work.get("id", "")
+            if title and body and url:
+                docs.append(_doc(url=url, title=title, body=body,
+                                 links=[], source="openalex", source_base=_base_url(url),
+                                 topic=topic))
+            if len(docs) >= max_results:
+                break
+        if len(results) < per_page:
+            break  # last page
+        page += 1
+        if page > 1:
+            time.sleep(0.5)
     return docs
 
 
 def fetch_arxiv(query: str, topic: str,
-                max_body: int | None = None, max_links: int | None = None) -> list[dict]:
-    r = _get("https://export.arxiv.org/api/query", params={
-        "search_query": f"all:{query}", "start": 0, "max_results": 5,
-    })
-    if not r:
-        return []
-    try:
-        root = ET.fromstring(r.text)
-    except ET.ParseError:
-        return []
+                max_body: int | None = None, max_links: int | None = None,
+                max_results: int = 5) -> list[dict]:
+    per_page = min(max_results, 100)  # stay well within arxiv's rate-limit guidance
     ns = {"a": "http://www.w3.org/2005/Atom"}
-    docs = []
-    for entry in root.findall("a:entry", ns):
-        def _t(tag: str) -> str:
-            el = entry.find(tag, ns)
-            return el.text.strip() if el is not None and el.text else ""
-        title = _t("a:title")
-        raw   = _t("a:summary")
-        body  = raw[:max_body] if max_body else raw
-        url   = _t("a:id").replace("http://", "https://")
-        if title and body and url:
-            docs.append(_doc(url=url, title=title, body=body,
-                             links=[], source="arxiv", source_base=_base_url(url),
-                             topic=topic))
+    docs: list[dict] = []
+    start = 0
+    while len(docs) < max_results:
+        r = _get("https://export.arxiv.org/api/query", params={
+            "search_query": f"all:{query}", "start": start, "max_results": per_page,
+        })
+        if not r:
+            break
+        try:
+            root = ET.fromstring(r.text)
+        except ET.ParseError:
+            break
+        entries = root.findall("a:entry", ns)
+        if not entries:
+            break
+        for entry in entries:
+            def _t(tag: str) -> str:
+                el = entry.find(tag, ns)
+                return el.text.strip() if el is not None and el.text else ""
+            title = _t("a:title")
+            raw   = _t("a:summary")
+            body  = raw[:max_body] if max_body else raw
+            url   = _t("a:id").replace("http://", "https://")
+            if title and body and url:
+                docs.append(_doc(url=url, title=title, body=body,
+                                 links=[], source="arxiv", source_base=_base_url(url),
+                                 topic=topic))
+            if len(docs) >= max_results:
+                break
+        if len(entries) < per_page:
+            break  # last page
+        start += per_page
+        if start > 0:
+            time.sleep(3.0)  # arxiv asks for a 3-second delay between paged requests
     return docs
 
 
 def fetch_semantic_scholar(query: str, topic: str,
-                           max_body: int | None = None, max_links: int | None = None) -> list[dict]:
-    r = _get("https://api.semanticscholar.org/graph/v1/paper/search", params={
-        "query": query, "limit": 6,
-        "fields": "title,abstract,tldr,externalIds,openAccessPdf",
-    })
-    if not r:
-        return []
-    docs = []
-    for paper in r.json().get("data", []):
-        title    = paper.get("title") or ""
-        abstract = paper.get("abstract") or ""
-        tldr     = (paper.get("tldr") or {}).get("text") or ""
-        raw      = f"{abstract}\n\nTL;DR: {tldr}" if tldr else abstract
-        body     = raw[:max_body] if max_body else raw
-        ext      = paper.get("externalIds") or {}
-        doi      = ext.get("DOI")
-        url      = (f"https://doi.org/{doi}" if doi else
-                    (paper.get("openAccessPdf") or {}).get("url") or "")
-        if title and body and url:
-            docs.append(_doc(url=url, title=title, body=body,
-                             links=[], source="semantic_scholar", source_base=_base_url(url),
-                             topic=topic))
+                           max_body: int | None = None, max_links: int | None = None,
+                           max_results: int = 6) -> list[dict]:
+    per_page = min(max_results, 100)  # API hard cap is 100
+    docs: list[dict] = []
+    offset = 0
+    while len(docs) < max_results:
+        r = _get("https://api.semanticscholar.org/graph/v1/paper/search", params={
+            "query": query, "limit": per_page, "offset": offset,
+            "fields": "title,abstract,tldr,externalIds,openAccessPdf",
+        })
+        if not r:
+            break
+        data = r.json().get("data", [])
+        if not data:
+            break
+        for paper in data:
+            title    = paper.get("title") or ""
+            abstract = paper.get("abstract") or ""
+            tldr     = (paper.get("tldr") or {}).get("text") or ""
+            raw      = f"{abstract}\n\nTL;DR: {tldr}" if tldr else abstract
+            body     = raw[:max_body] if max_body else raw
+            ext      = paper.get("externalIds") or {}
+            doi      = ext.get("DOI")
+            url      = (f"https://doi.org/{doi}" if doi else
+                        (paper.get("openAccessPdf") or {}).get("url") or "")
+            if title and body and url:
+                docs.append(_doc(url=url, title=title, body=body,
+                                 links=[], source="semantic_scholar", source_base=_base_url(url),
+                                 topic=topic))
+            if len(docs) >= max_results:
+                break
+        if len(data) < per_page:
+            break  # last page
+        offset += per_page
+        if offset > 0:
+            time.sleep(1.0)
     return docs
 
 
@@ -1229,8 +1271,11 @@ def _links(soup: BeautifulSoup, base_url: str, host: str,
 # ── DISPATCH ──────────────────────────────────────────────────────────────────
 
 def dispatch(source: str, value: str, topic: str,
-             max_body: int | None = None, max_links: int | None = None) -> list[dict]:
+             max_body: int | None = None, max_links: int | None = None,
+             max_results: int | None = None) -> list[dict]:
     kw = {"max_body": max_body, "max_links": max_links}
+    if max_results is not None:
+        kw["max_results"] = max_results
     match source:
         case "wikipedia":          return fetch_wikipedia(value, topic, **kw)
         case "wikipedia_category": return fetch_wikipedia_category(value, topic, **kw)
@@ -1314,14 +1359,15 @@ def load_corpus_links(corpus_dir: Path) -> list[tuple[str, str]]:
 # ── CRAWL ENGINE ─────────────────────────────────────────────────────────────
 
 def crawl(
-    clusters:  dict[str, dict],
-    depth:     int,
-    max_pages: int,
-    out_dir:   Path,
-    delay:     float,
-    overwrite: bool = False,
-    max_body:  int | None = None,
-    max_links: int | None = None,
+    clusters:     dict[str, dict],
+    depth:        int,
+    max_pages:    int,
+    out_dir:      Path,
+    delay:        float,
+    overwrite:    bool = False,
+    max_body:     int | None = None,
+    max_links:    int | None = None,
+    max_results:  int | None = None,
 ) -> None:
     queues: dict[str, deque] = {}
     for topic, conf in clusters.items():
@@ -1352,7 +1398,8 @@ def crawl(
             progress = True
 
             print(f"[{topic}][{source}][d={dlevel}] {value[:80]}")
-            docs = dispatch(source, value, topic, max_body=max_body, max_links=max_links)
+            docs = dispatch(source, value, topic, max_body=max_body, max_links=max_links,
+                            max_results=max_results)
 
             for doc in docs:
                 # Wikidata returns placeholder docs → re-queue as wikipedia
@@ -1429,9 +1476,10 @@ def expand(
     out_dir:    Path,
     delay:      float,
     overwrite:  bool,
-    max_body:   int | None = None,
-    max_links:  int | None = None,
-    topics:     set[str] | None = None,
+    max_body:     int | None = None,
+    max_links:    int | None = None,
+    max_results:  int | None = None,
+    topics:       set[str] | None = None,
 ) -> None:
     """
     Reads links from existing corpus files, randomly samples `sample` of them,
@@ -1469,7 +1517,7 @@ def expand(
 
     crawl(clusters, depth=depth, max_pages=max_pages,
           out_dir=out_dir, delay=delay, overwrite=overwrite,
-          max_body=max_body, max_links=max_links)
+          max_body=max_body, max_links=max_links, max_results=max_results)
 
 
 # ── CLI ───────────────────────────────────────────────────────────────────────
@@ -1521,10 +1569,13 @@ examples:
                    help="RNG seed for reproducible shuffles")
     p.add_argument("--overwrite",      action="store_true",
                    help="Re-fetch and overwrite existing files")
-    p.add_argument("--max-body",       type=int, default=None,
+    p.add_argument("--max-body",        type=int, default=None,
                    help="Truncate body text to N characters (default: no limit)")
-    p.add_argument("--max-links",      type=int, default=None,
+    p.add_argument("--max-links",       type=int, default=None,
                    help="Keep only the first N links per page (default: no limit)")
+    p.add_argument("--max-results",     type=int, default=None,
+                   help="Max results per query for academic APIs — openalex, arxiv, "
+                   "semantic_scholar (default: 5/5/6). Use e.g. 50 to paginate deeper.")
     args = p.parse_args()
 
     if args.seed is not None:
@@ -1543,9 +1594,10 @@ examples:
             out_dir    = out_dir,
             delay      = args.delay,
             overwrite  = args.overwrite,
-            max_body   = args.max_body,
-            max_links  = args.max_links,
-            topics     = {t.strip() for t in args.topics.split(",")} if args.topics else None
+            max_body    = args.max_body,
+            max_links   = args.max_links,
+            max_results = args.max_results,
+            topics      = {t.strip() for t in args.topics.split(",")} if args.topics else None
         )
         return
 
@@ -1595,14 +1647,15 @@ examples:
               f"{len(clusters)} topic(s): {', '.join(cats)}")
 
     crawl(
-        clusters  = clusters,
-        depth     = args.depth,
-        max_pages = args.max,
-        out_dir   = out_dir,
-        delay     = args.delay,
-        overwrite = args.overwrite,
-        max_body  = args.max_body,
-        max_links = args.max_links,
+        clusters    = clusters,
+        depth       = args.depth,
+        max_pages   = args.max,
+        out_dir     = out_dir,
+        delay       = args.delay,
+        overwrite   = args.overwrite,
+        max_body    = args.max_body,
+        max_links   = args.max_links,
+        max_results = args.max_results,
     )
 
 

--- a/data/scraper.py
+++ b/data/scraper.py
@@ -880,6 +880,7 @@ HEADERS = {
 }
 
 CROSS_THRESHOLD   = 3   # keyword hits before cross-topic seed injection
+WIKI_FOLLOW_LIMIT = 30  # max Wikipedia links re-queued per article at depth > 0
 CROSS_INJECT      = 1   # seeds injected per detected relation
 
 # Hosts whose discovered child-links we follow (depth > 0)
@@ -1016,6 +1017,33 @@ def fetch_wikidata(concept: str, topic: str) -> list[dict]:
         if title:
             url = _wiki_url(title)
             docs.append(_doc(url=url, title=title, body="", links=[],
+                             source="wikidata_ref", source_base=_base_url(url),
+                             topic=topic))
+    return docs
+
+
+def fetch_wikipedia_category(category: str, topic: str,
+                             max_members: int = 200, **_) -> list[dict]:
+    """Return stub docs for every article in a Wikipedia category.
+
+    Returned docs have source='wikidata_ref' so the crawl engine re-queues
+    them as proper wikipedia fetches — reusing the existing stub-requeue path.
+    Strips a leading 'Category:' prefix if the caller included it.
+    """
+    title = category.removeprefix("Category:").removeprefix("category:")
+    r = _get("https://en.wikipedia.org/w/api.php", params={
+        "action": "query", "list": "categorymembers",
+        "cmtitle": f"Category:{title}",
+        "cmlimit": max_members, "cmnamespace": 0, "format": "json",
+    })
+    if not r:
+        return []
+    docs = []
+    for member in r.json().get("query", {}).get("categorymembers", []):
+        art_title = member.get("title", "")
+        if art_title:
+            url = _wiki_url(art_title)
+            docs.append(_doc(url=url, title=art_title, body="", links=[],
                              source="wikidata_ref", source_base=_base_url(url),
                              topic=topic))
     return docs
@@ -1204,8 +1232,9 @@ def dispatch(source: str, value: str, topic: str,
              max_body: int | None = None, max_links: int | None = None) -> list[dict]:
     kw = {"max_body": max_body, "max_links": max_links}
     match source:
-        case "wikipedia":        return fetch_wikipedia(value, topic, **kw)
-        case "wikidata":         return fetch_wikidata(value, topic)
+        case "wikipedia":          return fetch_wikipedia(value, topic, **kw)
+        case "wikipedia_category": return fetch_wikipedia_category(value, topic, **kw)
+        case "wikidata":           return fetch_wikidata(value, topic)
         case "openalex":         return fetch_openalex(value, topic, **kw)
         case "arxiv":            return fetch_arxiv(value, topic, **kw)
         case "semantic_scholar": return fetch_semantic_scholar(value, topic, **kw)
@@ -1359,14 +1388,26 @@ def crawl(
                             injected_pairs.add(pair)
                             break
 
-                # Child-link expansion — only follow links to crawlable hosts
-                if dlevel < depth and source in ("html", "scikit", "stackoverflow"):
-                    for link in doc["links"]:
-                        if urlparse(link).netloc not in CRAWLABLE:
-                            continue
-                        lk = f"{source}::{link}"
-                        if lk not in visited:
-                            q.append((source, link, dlevel + 1))
+                # Child-link expansion
+                if dlevel < depth:
+                    if source == "wikipedia":
+                        # Links are Wikipedia URLs — extract title and re-queue
+                        # via the API rather than raw HTML. Shuffle so each run
+                        # explores a different neighbourhood.
+                        wiki_links = doc["links"][:]
+                        random.shuffle(wiki_links)
+                        for link in wiki_links[:WIKI_FOLLOW_LIMIT]:
+                            art = _title_from_wiki_url(link)
+                            lk  = f"wikipedia::{art}"
+                            if lk not in visited:
+                                q.append(("wikipedia", art, dlevel + 1))
+                    elif source in ("html", "scikit", "stackoverflow"):
+                        for link in doc["links"]:
+                            if urlparse(link).netloc not in CRAWLABLE:
+                                continue
+                            lk = f"{source}::{link}"
+                            if lk not in visited:
+                                q.append((source, link, dlevel + 1))
 
             if delay > 0:
                 time.sleep(delay)
@@ -1407,10 +1448,16 @@ def expand(
     sampled = candidates[:sample]
     print(f"Sampled {len(sampled)} / {len(candidates)} candidate links.")
 
-    # Group by topic so the round-robin engine still balances coverage
+    # Group by topic so the round-robin engine still balances coverage.
+    # Route Wikipedia URLs through the API adapter, not raw HTML.
     by_topic: dict[str, list] = {}
     for url, topic in sampled:
-        by_topic.setdefault(topic, []).append(("html", url))
+        if "wikipedia.org/wiki/" in url:
+            by_topic.setdefault(topic, []).append(
+                ("wikipedia", _title_from_wiki_url(url))
+            )
+        else:
+            by_topic.setdefault(topic, []).append(("html", url))
 
     clusters = {
         t: {
@@ -1453,6 +1500,9 @@ examples:
     p.add_argument("--sources",        help="Comma-separated source types to include "
                    "(wikipedia, arxiv, openalex, semantic_scholar, devto, github, "
                    "html, stackoverflow, wikidata)")
+    p.add_argument("--wiki-cats",      help="Comma-separated Wikipedia category names to "
+                   "scrape (e.g. 'Climate_change,Renewable_energy'). Seeds are injected "
+                   "into every selected topic cluster.")
     p.add_argument("--companies",      action="store_true",
                    help="Use corporate/NGO HTML sources instead of academic APIs")
     p.add_argument("--expand",         action="store_true",
@@ -1533,6 +1583,14 @@ examples:
             }
             for t, conf in clusters.items()
         }
+
+    if args.wiki_cats:
+        cats = [c.strip() for c in args.wiki_cats.split(",") if c.strip()]
+        for topic in clusters:
+            for cat in cats:
+                clusters[topic]["seeds"].append(("wikipedia_category", cat))
+        print(f"[wiki-cats] injected {len(cats)} category seed(s) into "
+              f"{len(clusters)} topic(s): {', '.join(cats)}")
 
     crawl(
         clusters  = clusters,


### PR DESCRIPTION
## Summary

### Wikipedia scalability
- **Enable Wikipedia link-following**: the crawl engine now re-queues linked article titles as new Wikipedia seeds (shuffled, capped at 30 per article). A single seed at `--depth 2` can now yield hundreds of Wikipedia articles instead of one.
- **Add `fetch_wikipedia_category()` + `--wiki-cats` CLI flag**: scrape entire Wikipedia categories by name without editing the seed lists in code (e.g. `--wiki-cats "Climate_change,Renewable_energy"`).
- **Fix `--expand` Wikipedia routing**: Wikipedia URLs found in the corpus link pool are now fetched via the Wikipedia API instead of raw HTML scraping, giving clean structured text.

### Academic API pagination
- **Add `--max-results` CLI flag**: openalex, arxiv, and semantic_scholar previously returned a hardcoded 5–6 results per query. Each adapter now paginates until `max_results` docs are collected or the API is exhausted. Defaults are unchanged so existing runs are unaffected.
  - openalex: up to 200 per page, 0.5s between pages
  - arxiv: up to 100 per page, 3s between pages (per their rate-limit guidance)
  - semantic_scholar: up to 100 per page, 1s between pages

### Bug fixes (from code review)
- **Trailing comma on `topics=`**: `--expand --topics` was silently passing a tuple instead of a set, causing the scraper to always exit with "No unscraped links found" regardless of corpus content.
- **Percent-encoded titles**: article titles like `Alzheimer%27s_disease` were passed raw to the Wikipedia API after link-following, causing silent misses. Fixed with `unquote()` at both requeue sites.
- **`TOPIC_CLUSTERS` mutation**: `--wiki-cats` was appending seeds directly to the module-level dict when `--sources` was not specified. Fixed by shallow-copying each topic's seeds list before appending.

## Usage examples
```bash
# Deep Wikipedia crawl — each seed fans out to 30 linked articles
python data/scraper.py --topics climate_change --sources wikipedia --depth 2 --max 300

# Scrape an entire Wikipedia category
python data/scraper.py --topics climate_change --wiki-cats "Climate_change,Renewable_energy" --max 200

# Get 50 results per academic query instead of 5
python data/scraper.py --topics ml_algorithms --sources openalex,arxiv --max-results 50 --max 500
```

## Test plan
- [ ] `--sources wikipedia --depth 2` saves more than ~7 Wikipedia docs per topic
- [ ] `--wiki-cats "Climate_change"` fetches category members and queues them as Wikipedia seeds
- [ ] `--expand --topics climate_change` finds candidates (trailing comma fix)
- [ ] Wikipedia links with special characters (apostrophes, em-dashes) are fetched correctly (percent-decode fix)
- [ ] `--max-results 20` returns 20 docs from openalex and arxiv across multiple pages